### PR TITLE
[WIP] ruby 2.2 support

### DIFF
--- a/test/soap/calc/test_calc_cgi.rb
+++ b/test/soap/calc/test_calc_cgi.rb
@@ -18,6 +18,13 @@ class TestCalcCGI < Test::Unit::TestCase
   )
   RUBYBIN << " -d" if $DEBUG
 
+  logger_gem = Gem::Specification.find { |s| s.name == 'logger-application' }
+  if logger_gem
+    logger_gem.load_paths.each do |path|
+      RUBYBIN << " -I #{path}"
+    end
+  end
+
   Port = 17171
 
   def setup

--- a/test/soap/calc/test_calc_cgi.rb
+++ b/test/soap/calc/test_calc_cgi.rb
@@ -18,10 +18,12 @@ class TestCalcCGI < Test::Unit::TestCase
   )
   RUBYBIN << " -d" if $DEBUG
 
-  logger_gem = Gem::Specification.find { |s| s.name == 'logger-application' }
-  if logger_gem
-    logger_gem.load_paths.each do |path|
-      RUBYBIN << " -I #{path}"
+  if RUBY_VERSION.to_f >= 2.2
+    logger_gem = Gem::Specification.find { |s| s.name == 'logger-application' }
+    if logger_gem
+      logger_gem.load_paths.each do |path|
+        RUBYBIN << " -I #{path}"
+      end
     end
   end
 

--- a/test/soap/header/server.cgi
+++ b/test/soap/header/server.cgi
@@ -1,5 +1,5 @@
 # encoding: UTF-8
-$:.unshift File.expand_path( File.dirname(__FILE__) + '../../../../lib') 
+$:.unshift File.expand_path( File.dirname(__FILE__) + '../../../../lib')
 
 require 'pstore'
 require 'soap/rpc/cgistub'

--- a/test/soap/header/test_authheader_cgi.rb
+++ b/test/soap/header/test_authheader_cgi.rb
@@ -20,10 +20,12 @@ class TestAuthHeaderCGI < Test::Unit::TestCase
   )
   RUBYBIN << " -d" if $DEBUG
 
-  logger_gem = Gem::Specification.find { |s| s.name == 'logger-application' }
-  if logger_gem
-    logger_gem.load_paths.each do |path|
-      RUBYBIN << " -I #{path}"
+  if RUBY_VERSION.to_f >= 2.2
+    logger_gem = Gem::Specification.find { |s| s.name == 'logger-application' }
+    if logger_gem
+      logger_gem.load_paths.each do |path|
+        RUBYBIN << " -I #{path}"
+      end
     end
   end
 

--- a/test/soap/header/test_authheader_cgi.rb
+++ b/test/soap/header/test_authheader_cgi.rb
@@ -19,7 +19,14 @@ class TestAuthHeaderCGI < Test::Unit::TestCase
     RbConfig::CONFIG["ruby_install_name"] + RbConfig::CONFIG["EXEEXT"]
   )
   RUBYBIN << " -d" if $DEBUG
-  
+
+  logger_gem = Gem::Specification.find { |s| s.name == 'logger-application' }
+  if logger_gem
+    logger_gem.load_paths.each do |path|
+      RUBYBIN << " -I #{path}"
+    end
+  end
+
   Port = 17171
   PortName = 'http://tempuri.org/authHeaderPort'
   SupportPortName = 'http://tempuri.org/authHeaderSupportPort'

--- a/test/soap/marshal/marshaltestlib.rb
+++ b/test/soap/marshal/marshaltestlib.rb
@@ -396,12 +396,12 @@ module MarshalTestLib
     # once there was a bug caused by usec overflow.  try a little harder.
     10.times do
       t = Time.now
-      marshal_equal(t,t.usec.to_s) {|t| t.tv_nsec }
+      marshal_equal(t,t.usec.to_s) {|t| t.tv_usec }
     end
   end
 
   def test_time_subclass
-    marshal_equal(MyTime.new(10)) {|t| t.tv_nsec }
+    marshal_equal(MyTime.new(10)) {|t| t.tv_usec }
   end
 
   def test_time_ivar

--- a/test/soap/marshal/marshaltestlib.rb
+++ b/test/soap/marshal/marshaltestlib.rb
@@ -27,15 +27,15 @@ module MarshalTestLib
     msg = msg ? msg + "(#{ caller[0] })" : caller[0]
     o2 = marshaltest(o1)
     assert_equal(o1.class, o2.class, msg)
-    
+
     iv1 = o1.instance_variables.sort
     iv2 = o2.instance_variables.sort
     assert_equal(iv1, iv2)
-    
+
     val1 = iv1.map {|var| o1.instance_eval( "#{var}" )}
     val2 = iv1.map {|var| o2.instance_eval( "#{var}" )}
     assert_equal(val1, val2, msg)
-    
+
     if block_given?
       assert_equal(yield(o1), yield(o2), msg)
     else
@@ -202,7 +202,7 @@ module MarshalTestLib
 
   def test_fixnum_ivar_self
     return if RUBY_VERSION.to_f > 1.9
-    begin    
+    begin
       o1 = 1
       o1.instance_eval { @iv = 1 }
       marshal_equal(o1) {|o| o.instance_eval { @iv }}
@@ -317,7 +317,7 @@ module MarshalTestLib
     class MyStruct
       def ==(rhs)
 	return true if __id__ == rhs.__id__
-	return false unless rhs.is_a?(::Struct) 
+	return false unless rhs.is_a?(::Struct)
 	return false if self.class != rhs.class
 	members.each do |member|
 	  return false if self.__send__(member) != rhs.__send__(member)
@@ -396,12 +396,12 @@ module MarshalTestLib
     # once there was a bug caused by usec overflow.  try a little harder.
     10.times do
       t = Time.now
-      marshal_equal(t,t.usec.to_s) {|t| t.tv_usec }
+      marshal_equal(t,t.usec.to_s) {|t| t.tv_nsec }
     end
   end
 
   def test_time_subclass
-    marshal_equal(MyTime.new(10)) {|t| t.tv_usec }
+    marshal_equal(MyTime.new(10)) {|t| t.tv_nsec }
   end
 
   def test_time_ivar
@@ -513,7 +513,7 @@ module MarshalTestLib
     class MyStruct2
       def ==(rhs)
 	return true if __id__ == rhs.__id__
-	return false unless rhs.is_a?(::Struct) 
+	return false unless rhs.is_a?(::Struct)
 	return false if self.class != rhs.class
 	members.each do |member|
 	  return false if self.__send__(member) != rhs.__send__(member)

--- a/test/soap/test_envelopenamespace.rb
+++ b/test/soap/test_envelopenamespace.rb
@@ -52,6 +52,7 @@ class TestEnvelopeNamespace < Test::Unit::TestCase
     @server.shutdown
     @server_thread.kill
     @server_thread.join
+    sleep 1
   end
 
   def teardown_client


### PR DESCRIPTION
Hi, I'd like to work on ruby 2.2 support, and maybe refactor some of the test suite along the way. I've managed to get the test suite passing in ruby 2.2, using a few 'hacks'. 

Some techniques used in the test suite make them a 
little brittle.

Issue 1: Webrick + CGI scripts as test soap servers
Webrick starts the CGI script in a new environment,
without respecting rvm gemsets or bundler. Therefore
the necessary 'logger-application' gem in ruby 2.2
is not available. I tried to solve this, by looking
up the logger-application load path in the main 
process, and passing it as "-I ..." option to the
ruby bin used for the CGI script. Works now in 2.2,
does not break in 2.1. On the long run, CGI should
be removed from the tests, i think.

Issue 2: test/soap/marshal/mashaltestlib contains
marshalling test for the Time class which compare
marshalled/unmarshalled Time instances via musecs.
These fail once in a while (more often in ruby 2.2),
due to differences of 1musec. My guess is some kind
of rounding issue somewhere. I tried comparing
nsec, which is a little bit more reliable, but still
fragile. There must be a better way to compare the
Time objects.

Issue 3: In test/soap/test_envelopenamespace.rb the
Webrick test server takes a little to long to shutdown
and therefore blocks the 17171 port for the next test
(test_custommap). When that happens, all consequent
tests fail with "address already in use". I tried
debugging it, watching the Webrick status and the
server thread status. Webrick is getting stopped,
the server thread terminates, but it still blocks
the port for another few msecs. For now i have put
a `sleep(1)` behind the server termination, which
works fine, but is a little hacky. I can't figure out
why the Webrick shutdown is an issue only in this
particular test.
