### PR TITLE
Allow HTTP_PROXY settings to use username and password

### DIFF
--- a/lib/soap/netHttpClient.rb
+++ b/lib/soap/netHttpClient.rb
@@ -169,8 +169,10 @@ private
     unless no_proxy?(url)
       proxy_host = @proxy.host
       proxy_port = @proxy.port
+      proxy_user = @proxy.user
+      proxy_password = @proxy.password
     end
-    http = Net::HTTP::Proxy(proxy_host, proxy_port).new(url.host, url.port)
+    http = Net::HTTP::Proxy(proxy_host, proxy_port, proxy_user, proxy_password).new(url.host, url.port)
     if http.respond_to?(:set_debug_output)
       http.set_debug_output(@debug_dev)
     end


### PR DESCRIPTION
I am using an http proxy service (FIXIE) on Heroku that requires a username and password. I've added 4 lines that will pass along the username and password from the HTTP_PROXY environment variable. Formerly just the hostname and port were used.

Would you like to merge this into your master?