### PR TITLE
add support for group element

### DIFF
--- a/lib/wsdl/soap/classDefCreator.rb
+++ b/lib/wsdl/soap/classDefCreator.rb
@@ -276,6 +276,12 @@ private
     parentmodule = mapped_class_name(qname, mpath)
     init_lines, init_params =
       parse_elements(c, typedef.elements, qname.namespace, parentmodule)
+    if typedef.content && (WSDL::XMLSchema::Group === typedef.content)
+        g_init_lines, g_init_params =
+            parse_elements(c, typedef.content.refelement.elements, qname.namespace, parentmodule)
+        init_lines = (g_init_lines + init_lines)
+        init_params = (g_init_params + init_params)
+    end
     unless typedef.attributes.empty?
       define_attribute(c, typedef.attributes)
       init_lines << "@__xmlattr = {}"
@@ -337,6 +343,9 @@ private
         init_lines.concat(child_init_lines)
         init_params.concat(child_init_params)
       when WSDL::XMLSchema::Group
+        if element.ref && element.content.nil?
+            element.content = element.refelement
+        end
         if element.content.nil?
           warn("no group definition found: #{element}")
           next

--- a/lib/wsdl/soap/mappingRegistryCreatorSupport.rb
+++ b/lib/wsdl/soap/mappingRegistryCreatorSupport.rb
@@ -62,6 +62,11 @@ module MappingRegistryCreatorSupport
     parentmodule = var[:class]
     parsed_element =
       parse_elements(typedef.elements, qname.namespace, parentmodule, opt)
+    if typedef.content && (WSDL::XMLSchema::Group === typedef.content) && typedef.elements.empty?
+        g_parsed_element =
+            parse_elements(typedef.content.refelement.elements, qname.namespace, parentmodule, opt)
+        parsed_element = (g_parsed_element + parsed_element)        
+    end
     if typedef.choice?
       parsed_element.unshift(:choice)
     end

--- a/lib/wsdl/xmlSchema/group.rb
+++ b/lib/wsdl/xmlSchema/group.rb
@@ -9,13 +9,14 @@
 
 require 'wsdl/info'
 require 'wsdl/xmlSchema/ref'
+require 'wsdl/xmlSchema/complexType'
 
 
 module WSDL
 module XMLSchema
 
 
-class Group < Info
+class Group < ComplexType
   include Ref
 
   attr_writer :name	# required
@@ -89,7 +90,7 @@ class Group < Info
     end
   end
 
-private
+#private
 
   def refelement
     @refelement ||= (@ref ? root.collect_modelgroups[@ref] : nil)


### PR DESCRIPTION
I don't study any specification, byt my code works for /usr/bin/xsd2ruby.rb  --xsd filter.xsd --mapper --mapping_registry --force --classdef pohoda-xsd --module_path 'PohodaXsd'

Old code generate exeption with xsd like:

<?xml version="1.0" encoding="utf-8"?>
<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
                        xmlns:ftr="http://www.stormware.cz/schema/version_2/filter.xsd"
                        xmlns="http://www.stormware.cz/schema/version_2/filter.xsd"
                        targetNamespace="http://www.stormware.cz/schema/version_2/filter.xsd"
                        elementFormDefault="qualified"
>

<xsd:complexType name="requestInvoiceType">
  <xsd:group ref="ftr:groupFilter_1"/>
</xsd:complexType>

<xsd:group name="groupFilter_1">
        <xsd:all>
                <xsd:element name="filter" type="ftr:filterDocsType" minOccurs="0">
                        <xsd:annotation>
                                <xsd:documentation>Seznam polí, podle kterých se budou filtrovat doklady.</xsd:documentation>
                        </xsd:annotation>
                </xsd:element>
                <xsd:element name="userFilterName" type="xsd:string" minOccurs="0">
                        <xsd:annotation>
                                <xsd:documentation>Identifikátor uživatelského filtru v požadované agendě, který má být použit pro filtraci záznamů.</xsd:documentation>
                        </xsd:annotation>
                </xsd:element>
        </xsd:all>
</xsd:group>

</xsd:schema>
