### PR TITLE
Support 2.4/2.5 rubies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,9 @@ rvm:
   - 2.0.0
   - 2.1
   - 2.2
-  - 2.3
+  - 2.3.7
+  - 2.4.4
+  - 2.5
 env:
   - SOAP4R_PARSERS=oxparser
   - SOAP4R_PARSERS=nokogiriparser
@@ -23,11 +25,9 @@ matrix:
 
   allow_failures:
     - rvm: 1.8.7
-      env: SOAP4R_PARSERS=oxparser
     - rvm: jruby
     - rvm: rbx
     - env: SOAP4R_PARSERS=libxmlparser
-    - rvm: 2.3
 
 notifications:
   recipients:

--- a/Gemfile
+++ b/Gemfile
@@ -38,7 +38,6 @@ group :test do
     gem 'test-unit', '~> 1.2.3'
     gem 'rake', '~> 10.4.2'
   else
-    gem 'test_xml'
     gem 'test-unit'
     gem 'rake'
   end

--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,11 @@ if RUBY_VERSION.to_f <= 1.8
 else
   gem 'httpclient'   # 2.1.5.2
   gem 'htmlentities', '~> 4.3.3'    # Require this if OxParser's built-in "Special Character" conversion isn't sufficient for your needs.
-  gem 'nokogiri',     '~> 1.6.6'    # nokogiriparser ; Uses libxml2, libxslt, and zlib
+  if RUBY_VERSION.to_f <= 2.2
+    gem 'nokogiri',     '~> 1.6.6'    # nokogiriparser ; Uses libxml2, libxslt, and zlib
+  else
+    gem 'nokogiri',   '~> 1.8.2'
+  end
   gem 'oga'                         # ogaparser      ; Pure-Ruby Alternative ; Ruby 1.9 and above only.
   gem 'logger-application', :require=>'logger-application'
 end
@@ -15,10 +19,16 @@ end
 if RUBY_PLATFORM =~ /java/
   gem 'libxml-jruby'                 # libxmlparser (Java Equivalent)
 else
-  platform :ruby_18, :ruby_19 do
+  if RUBY_VERSION.to_f <= 1.9
     gem 'libxml-ruby', '~> 2.8.0'
+  else
+    gem 'libxml-ruby', '~> 3.1.0'
   end
-  gem 'ox'                            # oxparser       ; Uses its own custom C-library
+  if RUBY_VERSION.to_f <= 1.8
+    gem 'ox', '~> 2.4.5'
+  else
+    gem 'ox'                          # oxparser       ; Uses its own custom C-library
+  end
   gem 'curb'
 end
 
@@ -28,12 +38,15 @@ group :test do
     gem 'test-unit', '~> 1.2.3'
     gem 'rake', '~> 10.4.2'
   else
+    gem 'test_xml'
     gem 'test-unit'
     gem 'rake'
   end
-  platform :ruby_18, :ruby_19 do
+  if RUBY_VERSION.to_f <= 1.9
     gem 'json', '~> 1.8' # Mostly for Code Climate's benefit if running on Ruby 1.9 or less.
-  end  
+  else
+    gem 'json', '~> 2.1'
+  end
   gem 'rubyjedi-testunitxml', :git=>'https://github.com/rubyjedi/testunitxml.git', :branch=>'master'
   gem "codeclimate-test-reporter", :require=>nil if RUBY_VERSION.to_f >= 1.9
   
@@ -44,6 +57,7 @@ group :test do
   # gem 'ruby-termios'               # Unroller requires this . . .
   # gem 'unroller', :git=>'https://github.com/jayjlawrence/unroller.git', :branch=>'master'
 
-  gem 'byebug' if RUBY_VERSION.to_f >= 2.0
+  gem 'pry-byebug', '< 3.6' if RUBY_VERSION.to_f >= 2.0
+  gem 'byebug', '< 10' if RUBY_VERSION.to_f >= 2.0
   gem 'soap4r-ng', :path=>'.'  # Make our development copy (this directory) available as a Gem via Bundler. Useful for running tests.
 end

--- a/gemfiles/httpclient.gemfile
+++ b/gemfiles/httpclient.gemfile
@@ -36,7 +36,6 @@ group :test do
     gem 'test-unit', '~> 1.2.3'
     gem 'rake', '~> 10.4.2'
   else
-    gem 'test_xml'
     gem 'test-unit'
     gem 'rake'
   end

--- a/gemfiles/httpclient.gemfile
+++ b/gemfiles/httpclient.gemfile
@@ -6,7 +6,11 @@ if RUBY_VERSION.to_f <= 1.8
 else
   gem 'httpclient'   # 2.1.5.2
   gem 'htmlentities', '~> 4.3.3'    # Require this if OxParser's built-in "Special Character" conversion isn't sufficient for your needs.
-  gem 'nokogiri',     '~> 1.6.6'    # nokogiriparser ; Uses libxml2, libxslt, and zlib
+  if RUBY_VERSION.to_f <= 2.2
+    gem 'nokogiri',     '~> 1.6.6'    # nokogiriparser ; Uses libxml2, libxslt, and zlib
+  else
+    gem 'nokogiri',   '~> 1.8.2'
+  end
   gem 'oga'                         # ogaparser      ; Pure-Ruby Alternative ; Ruby 1.9 and above only.
   gem 'logger-application', :require=>'logger-application'
 end
@@ -14,10 +18,16 @@ end
 if RUBY_PLATFORM =~ /java/
   gem 'libxml-jruby'                 # libxmlparser (Java Equivalent)
 else
-  platform :ruby_18, :ruby_19 do
+  if RUBY_VERSION.to_f <= 1.9
     gem 'libxml-ruby', '~> 2.8.0'
+  else
+    gem 'libxml-ruby', '~> 3.1.0'
   end
-  gem 'ox'                            # oxparser       ; Uses its own custom C-library
+  if RUBY_VERSION.to_f <= 1.8
+    gem 'ox', '~> 2.4.5'
+  else
+    gem 'ox'                          # oxparser       ; Uses its own custom C-library
+  end
 end
 
 ### Testing Support ###
@@ -26,12 +36,15 @@ group :test do
     gem 'test-unit', '~> 1.2.3'
     gem 'rake', '~> 10.4.2'
   else
+    gem 'test_xml'
     gem 'test-unit'
     gem 'rake'
   end
 
-  platform :ruby_18, :ruby_19 do
+  if RUBY_VERSION.to_f <= 1.9
     gem 'json', '~> 1.8' # Mostly for Code Climate's benefit if running on Ruby 1.9 or less.
+  else
+    gem 'json', '~> 2.1'
   end
   gem 'rubyjedi-testunitxml', :git=>'https://github.com/rubyjedi/testunitxml.git', :branch=>'master'
   gem "codeclimate-test-reporter", :require=>nil if RUBY_VERSION.to_f >= 1.9

--- a/lib/soap/mapping/rubytypeFactory.rb
+++ b/lib/soap/mapping/rubytypeFactory.rb
@@ -6,6 +6,10 @@
 # redistribute it and/or modify it under the same terms of Ruby's license;
 # either the dual license version in 2003, or any later version.
 
+old_verbose, $VERBOSE = $VERBOSE, nil # silence warnings
+DATA_PRESENT = defined?(Data)
+DataShim = Kernel.const_get('Data') if DATA_PRESENT
+$VERBOSE = old_verbose
 
 module SOAP
 module Mapping
@@ -38,6 +42,7 @@ class RubytypeFactory < Factory
 
   def obj2soap(soap_class, obj, info, map)
     param = nil
+
     case obj
     when ::String
       unless @allow_original_mapping
@@ -193,7 +198,7 @@ class RubytypeFactory < Factory
         param.add('member', ele_member)
         addiv2soapattr(param, obj, map)
       end
-    when ::IO, ::Binding, ::Data, ::Dir, ::File::Stat,
+    when ::IO, ::Binding, DataShim, ::Dir, ::File::Stat,
         ::MatchData, Method, ::Proc, ::Process::Status, ::Thread,
         ::ThreadGroup, ::UnboundMethod
       return nil

--- a/lib/soap/property.rb
+++ b/lib/soap/property.rb
@@ -33,7 +33,9 @@ module SOAP
 #     aaa.hhh = iii
 #
 class Property
-  FrozenError = (RUBY_VERSION >= "1.9.0") ? RuntimeError : TypeError
+  unless defined?(FrozenError) # defined since 2.5
+    FrozenError = (RUBY_VERSION >= "1.9.0") ? RuntimeError : TypeError
+  end
 
   include Enumerable
 

--- a/lib/xsd/xmlparser/oxparser.rb
+++ b/lib/xsd/xmlparser/oxparser.rb
@@ -28,7 +28,7 @@ class OxParser < XSD::XMLParser::Parser
       ::Ox.sax_parse(handler, string, {:symbolize=> false, :convert_special=> true, :skip=> :skip_return} )
     else
       # Use HTMLEntities Decoder.  Leave the special-character conversion alone and let HTMLEntities decode it for us.
-      ::Ox.sax_parse(handler, string, {})
+      ::Ox.sax_parse(handler, string, {:skip=> :skip_none})
     end
   end
   

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -3,8 +3,8 @@ require 'test/unit'
 require 'test/unit/xml' ## RubyJedi
 
 if RUBY_VERSION.to_f >= 1.9
-  require "codeclimate-test-reporter"
-  CodeClimate::TestReporter.start
+  require 'simplecov'
+  SimpleCov.start
 end
 
 ENV['DEBUG_SOAP4R'] = 'true' ## Needed to force wsdl2ruby.rb and xsd2ruby.rb to use DEVELOPMENT soap4r libs instead of installed soap4r libs

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -10,3 +10,6 @@ end
 ENV['DEBUG_SOAP4R'] = 'true' ## Needed to force wsdl2ruby.rb and xsd2ruby.rb to use DEVELOPMENT soap4r libs instead of installed soap4r libs
 $DEBUG = !!ENV['WIREDUMPS']
 
+# see https://bugs.ruby-lang.org/issues/13181 & https://github.com/ruby/ruby/commit/86bfcc2da0
+RUBY_GEM_VERSION = Gem::Version.new(RUBY_VERSION)
+RESCUE_LINE_NUMBERS_FIXED = (RUBY_GEM_VERSION >= Gem::Version.new('2.4.3')) || (RUBY_GEM_VERSION >= Gem::Version.new('2.3.6') && RUBY_GEM_VERSION < Gem::Version.new('2.4.0'))

--- a/test/soap/auth/test_basic.rb
+++ b/test/soap/auth/test_basic.rb
@@ -32,7 +32,7 @@ class TestBasic < Test::Unit::TestCase
   end
 
   def setup_server
-    @server = WEBrick::HTTPServer.new(
+    @server = TestUtil.webrick_http_server(
       :BindAddress => "0.0.0.0",
       :Logger => @logger,
       :Port => Port,
@@ -50,11 +50,12 @@ class TestBasic < Test::Unit::TestCase
       '/',
       WEBrick::HTTPServlet::ProcHandler.new(method(:do_server_proc).to_proc)
     )
+
     @server_thread = TestUtil.start_server_thread(@server)
   end
 
   def setup_proxyserver
-    @proxyserver = WEBrick::HTTPProxyServer.new(
+    @proxyserver = TestUtil.webrick_http_server(
       :BindAddress => "0.0.0.0",
       :Logger => @logger,
       :Port => ProxyPort,

--- a/test/soap/auth/test_digest.rb
+++ b/test/soap/auth/test_digest.rb
@@ -32,7 +32,7 @@ class TestDigest < Test::Unit::TestCase
   end
 
   def setup_server
-    @server = WEBrick::HTTPServer.new(
+    @server = TestUtil.webrick_http_server(
       :BindAddress => "0.0.0.0",
       :Logger => @logger,
       :Port => Port,
@@ -55,7 +55,7 @@ class TestDigest < Test::Unit::TestCase
   end
 
   def setup_proxyserver
-    @proxyserver = WEBrick::HTTPProxyServer.new(
+    @proxyserver = TestUtil.webrick_proxy_server(
       :BindAddress => "0.0.0.0",
       :Logger => @logger,
       :Port => ProxyPort,

--- a/test/soap/calc/test_calc2.rb
+++ b/test/soap/calc/test_calc2.rb
@@ -15,10 +15,7 @@ class TestCalc2 < Test::Unit::TestCase
   def setup
     @server = CalcServer2.new('CalcServer', 'http://tempuri.org/calcService', '0.0.0.0', Port)
     @server.level = Logger::Severity::ERROR
-    @t = Thread.new {
-      Thread.current.abort_on_exception = true
-      @server.start
-    }
+    @t = TestUtil.start_server_thread(@server)
     @endpoint = "http://localhost:#{Port}/"
     @var = SOAP::RPC::Driver.new(@endpoint, 'http://tempuri.org/calcService')
     @var.wiredump_dev = STDERR if $DEBUG

--- a/test/soap/fault/test_customfault.rb
+++ b/test/soap/fault/test_customfault.rb
@@ -26,10 +26,7 @@ class TestCustomFault < Test::Unit::TestCase
   def setup
     @server = CustomFaultServer.new('customfault', 'urn:customfault', '0.0.0.0', Port)
     @server.level = Logger::Severity::ERROR
-    @t = Thread.new {
-      Thread.current.abort_on_exception = true
-      @server.start
-    }
+    @t = TestUtil.start_server_thread(@server)
     @endpoint = "http://localhost:#{Port}/"
     @client = SOAP::RPC::Driver.new(@endpoint, 'urn:customfault')
     @client.wiredump_dev = STDERR if $DEBUG

--- a/test/soap/header/test_authheader_cgi.rb
+++ b/test/soap/header/test_authheader_cgi.rb
@@ -23,7 +23,8 @@ class TestAuthHeaderCGI < Test::Unit::TestCase
   if RUBY_VERSION.to_f >= 2.2
     logger_gem = Gem::Specification.find { |s| s.name == 'logger-application' }
     if logger_gem
-      logger_gem.load_paths.each do |path|
+      paths = logger_gem.respond_to?(:full_require_paths) ? logger_gem.full_require_paths : logger_gem.load_paths
+      paths.each do |path|
         RUBYBIN << " -I #{path}"
       end
     end

--- a/test/soap/header/test_authheader_cgi.rb
+++ b/test/soap/header/test_authheader_cgi.rb
@@ -70,7 +70,7 @@ class TestAuthHeaderCGI < Test::Unit::TestCase
     @endpoint = "http://localhost:#{Port}/server.cgi"
     logger = Logger.new(STDERR)
     logger.level = Logger::Severity::ERROR
-    @server = WEBrick::HTTPServer.new(
+    @server = TestUtil.webrick_http_server(
       :BindAddress => "0.0.0.0",
       :Logger => logger,
       :Port => Port,
@@ -79,10 +79,7 @@ class TestAuthHeaderCGI < Test::Unit::TestCase
       :CGIPathEnv => ENV['PATH'],
       :CGIInterpreter => RUBYBIN
     )
-    @t = Thread.new {
-      Thread.current.abort_on_exception = true
-      @server.start
-    }
+    @t = TestUtil.start_server_thread(@server)
   end
 
   def setup_client

--- a/test/soap/helloworld/test_helloworld.rb
+++ b/test/soap/helloworld/test_helloworld.rb
@@ -15,10 +15,7 @@ class TestHelloWorld < Test::Unit::TestCase
   def setup
     @server = HelloWorldServer.new('hws', 'urn:hws', '0.0.0.0', Port)
     @server.level = Logger::Severity::ERROR
-    @t = Thread.new {
-      Thread.current.abort_on_exception = true
-      @server.start
-    }
+    @t = TestUtil.start_server_thread(@server)
     @endpoint = "http://localhost:#{Port}/"
     @client = SOAP::RPC::Driver.new(@endpoint, 'urn:hws')
     @client.wiredump_dev = STDERR if $DEBUG

--- a/test/soap/ssl/test_ssl.rb
+++ b/test/soap/ssl/test_ssl.rb
@@ -99,7 +99,7 @@ class TestSSL < Test::Unit::TestCase
     assert_equal("Hello World, from ssl client", @client.hello_world("ssl client"))
     assert(@verify_callback_called)
     #
-    cfg["protocol.http.ssl_config.verify_depth"] = "1"
+    cfg["protocol.http.ssl_config.verify_depth"] = "0"
     @verify_callback_called = false
     begin
       @client.hello_world("ssl client")
@@ -128,8 +128,7 @@ class TestSSL < Test::Unit::TestCase
     File.open(testpropertyname, "w") do |f|
       f<<<<__EOP__
 protocol.http.ssl_config.verify_mode = OpenSSL::SSL::VERIFY_PEER
-# depth: 1 causes an error (intentional)
-protocol.http.ssl_config.verify_depth = 1
+protocol.http.ssl_config.verify_depth = 0
 protocol.http.ssl_config.client_cert = #{File.join(DIR, 'client.cert')}
 protocol.http.ssl_config.client_key = #{File.join(DIR, 'client.key')}
 protocol.http.ssl_config.ca_file = #{File.join(DIR, 'ca.cert')}

--- a/test/soap/test_cookie.rb
+++ b/test/soap/test_cookie.rb
@@ -50,7 +50,7 @@ class TestCookie < Test::Unit::TestCase
   end
 
   def setup_server
-    @server = WEBrick::HTTPServer.new(
+    @server = TestUtil.webrick_http_server(
       :BindAddress => "0.0.0.0",
       :Logger => @logger,
       :Port => Port,

--- a/test/soap/test_custommap.rb
+++ b/test/soap/test_custommap.rb
@@ -76,8 +76,21 @@ class TestMap < Test::Unit::TestCase
     @client.reset_stream if @client
   end
 
-  def test_map
+  def test_map_with_frozen_literals
     h = {'a' => 1, 'b' => 2}
+    soap = SOAP::Marshal.marshal(h)
+    puts soap if $DEBUG
+    obj = SOAP::Marshal.unmarshal(soap)
+    assert_equal(h, obj)
+    #
+    soap = SOAP::Marshal.marshal(h, Map)
+    puts soap if $DEBUG
+    obj = SOAP::Marshal.unmarshal(soap, Map)
+    assert_equal(h, obj)
+  end
+
+  def test_map
+    h = {String.new('a') => 1, String.new('b') => 2}
     soap = SOAP::Marshal.marshal(h)
     puts soap if $DEBUG
     obj = SOAP::Marshal.unmarshal(soap)

--- a/test/soap/test_envelopenamespace.rb
+++ b/test/soap/test_envelopenamespace.rb
@@ -29,7 +29,7 @@ class TestEnvelopeNamespace < Test::Unit::TestCase
   end
 
   def setup_server
-    @server = WEBrick::HTTPServer.new(
+    @server = TestUtil.webrick_http_server(
       :BindAddress => "0.0.0.0",
       :Logger => @logger,
       :Port => Port,

--- a/test/soap/test_nestedexception.rb
+++ b/test/soap/test_nestedexception.rb
@@ -42,10 +42,10 @@ class TestNestedException < Test::Unit::TestCase
   if (RUBY_VERSION.to_f >= 1.9)
     TOBE = [
       ":16:in `rescue in foo'",
-      ":13:in `foo'",
+      ":#{RESCUE_LINE_NUMBERS_FIXED ? 12 : 13}:in `foo'",
       ":34:in `test_nestedexception'",
       ":24:in `rescue in bar': bar (SOAP::TestNestedException::MyError) [NESTED]",
-      ":21:in `bar'",
+      ":#{RESCUE_LINE_NUMBERS_FIXED ? 20 : 21}:in `bar'",
       ":14:in `foo'",
       ":34:in `test_nestedexception'",
       ":29:in `baz': baz (SOAP::TestNestedException::MyError) [NESTED]",

--- a/test/soap/test_property.rb
+++ b/test/soap/test_property.rb
@@ -8,7 +8,9 @@ module SOAP
 
 
 class TestProperty < Test::Unit::TestCase
-  FrozenError = (RUBY_VERSION >= "1.9.0") ? RuntimeError : TypeError
+  unless defined?(FrozenError) # defined since 2.5
+    FrozenError = (RUBY_VERSION >= "1.9.0") ? RuntimeError : TypeError
+  end
 
   def setup
     @prop = ::SOAP::Property.new

--- a/test/soap/test_streamhandler.rb
+++ b/test/soap/test_streamhandler.rb
@@ -32,7 +32,7 @@ class TestStreamHandler < Test::Unit::TestCase
   end
 
   def setup_server
-    @server = WEBrick::HTTPServer.new(
+    @server = TestUtil.webrick_http_server(
       :BindAddress => "0.0.0.0",
       :Logger => @logger,
       :Port => Port,
@@ -58,7 +58,7 @@ class TestStreamHandler < Test::Unit::TestCase
   end
 
   def setup_proxyserver
-    @proxyserver = WEBrick::HTTPProxyServer.new(
+    @proxyserver = TestUtil.webrick_proxy_server(
       :BindAddress => "0.0.0.0",
       :Logger => @logger,
       :Port => ProxyPort,

--- a/test/soap/test_styleuse.rb
+++ b/test/soap/test_styleuse.rb
@@ -309,7 +309,11 @@ class TestStyleUse < Test::Unit::TestCase
   def test_doc_enc_doc_lit
     ret1, ret2 = @client.doc_enc_doc_lit('a', 1)
     # literal Array
-    assert_equal(['String', 'Fixnum'], ret1['obj1']['klass'])
+    if (RUBY_VERSION.to_f <= 2.3)
+      assert_equal(['String', 'Fixnum'], ret1['obj1']['klass'])
+    else
+      assert_equal(['String', 'Integer'], ret1['obj1']['klass'])
+    end
     # same value
     assert_equal(ret1['obj1']['klass'], ret2['obj2']['klass'])
     # not the same object (not encoded)

--- a/test/testutil.rb
+++ b/test/testutil.rb
@@ -52,4 +52,23 @@ module TestUtil
     }
     t
   end
+
+  def self.webrick_http_server(options)
+    webrick_server(WEBrick::HTTPServer, options)
+  end
+
+  def self.webrick_proxy_server(options)
+    webrick_server(WEBrick::HTTPProxyServer, options)
+  end
+
+  def self.webrick_server(klass, options)
+    try = 0
+    begin
+      klass.new(options)
+    rescue Errno::EADDRINUSE => e
+      STDERR.puts "Wait for available port for #{klass.name} (#{e.message}) [#{Thread.list.inspect}]"
+      sleep 1
+      ((try += 1) < 5) ? retry : raise(e)
+    end
+  end
 end

--- a/test/wsdl/datetime/test_datetime.rb
+++ b/test/wsdl/datetime/test_datetime.rb
@@ -22,10 +22,7 @@ class TestDatetime < Test::Unit::TestCase
   def setup_server
     @server = DatetimePortTypeApp.new('Datetime server', nil, '0.0.0.0', Port)
     @server.level = Logger::Severity::ERROR
-    @t = Thread.new {
-      Thread.current.abort_on_exception = true
-      @server.start
-    }
+    @t = TestUtil.start_server_thread(@server)
   end
 
   def setup_client

--- a/test/wsdl/map/test_map.rb
+++ b/test/wsdl/map/test_map.rb
@@ -39,10 +39,7 @@ class TestMap < Test::Unit::TestCase
       :SOAPDefaultNamespace => "urn:map"
     )
     @server.level = Logger::Severity::ERROR
-    @t = Thread.new {
-      Thread.current.abort_on_exception = true
-      @server.start
-    }
+    @t = TestUtil.start_server_thread(@server)
   end
 
   def setup_client

--- a/test/wsdl/raa/test_raa.rb
+++ b/test/wsdl/raa/test_raa.rb
@@ -38,10 +38,7 @@ class TestRAA < Test::Unit::TestCase
     require pathname('RAAService.rb')
     @server = RAABaseServicePortTypeApp.new('RAA server', nil, '0.0.0.0', Port)
     @server.level = Logger::Severity::ERROR
-    @t = Thread.new {
-      Thread.current.abort_on_exception = true
-      @server.start
-    }
+    @t = TestUtil.start_server_thread(@server)
   end
 
   def setup_client

--- a/test/wsdl/soap/test_soapbodyparts.rb
+++ b/test/wsdl/soap/test_soapbodyparts.rb
@@ -39,10 +39,7 @@ class TestSOAPBodyParts < Test::Unit::TestCase
   def setup_server
     @server = Server.new('Test', "urn:www.example.com:soapbodyparts:v1", '0.0.0.0', Port)
     @server.level = Logger::Severity::ERROR
-    @t = Thread.new {
-      Thread.current.abort_on_exception = true
-      @server.start
-    }
+    @t = TestUtil.start_server_thread(@server)
   end
 
   def setup_client


### PR DESCRIPTION
After this the gem should properly work on ruby 1.9-2.5 inclusively, without warnings 🎉 

What's addressed inside:
- [x] warnings/missing Fixnum/Bignum/Data
- [x] new FrozenError
- [x] fixes related updated bundler, webrick, ox

What I'm concerned about (maybe we'd better change test logic)
- [x] some workarounds for a ruby bug with line numbers and new did-you-mean enabled by default
- [x] I had to change openssl verify_depth to 0 since with 1 the insufficient cert chain doesn't raise (both travis & locally the same) - if you understand this, please, tell me what you think :)

Also handled some things discussed in #8 which should make further testing more predictable
- [x] time-dependent specs are executed with stubbed time
- [x] errors caused by "port is used" are auto retried now

What's totally broken after this:
- ruby-1.8
- anything with libxmlparser

Sorry for a big PR, feel free to take some commits apart and comment on.