### PR TITLE
Add "options" Argument to XSD Mapper/Mapping Methods

### DIFF
--- a/lib/xsd/mapping.rb
+++ b/lib/xsd/mapping.rb
@@ -20,12 +20,12 @@ module XSD
 module Mapping
   MappingRegistry = SOAP::Mapping::LiteralRegistry.new
 
-  def self.obj2xml(obj, elename = nil, io = nil)
-    Mapper.new(MappingRegistry).obj2xml(obj, elename, io)
+  def self.obj2xml(obj, elename = nil, io = nil, options = {})
+    Mapper.new(MappingRegistry).obj2xml(obj, elename, io, options)
   end
 
-  def self.xml2obj(stream, klass = nil)
-    Mapper.new(MappingRegistry).xml2obj(stream, klass)
+  def self.xml2obj(stream, klass = nil, options = {})
+    Mapper.new(MappingRegistry).xml2obj(stream, klass, options)
   end
 
   class Mapper
@@ -39,8 +39,8 @@ module Mapping
       @registry = registry
     end
 
-    def obj2xml(obj, elename = nil, io = nil)
-      opt = MAPPING_OPT.dup
+    def obj2xml(obj, elename = nil, io = nil, options = {})
+      opt = MAPPING_OPT.dup.merge(options)
       unless elename
         if definition = @registry.elename_schema_definition_from_class(obj.class)
           elename = definition.elename
@@ -57,8 +57,9 @@ module Mapping
       generator.generate(soap, io)
     end
 
-    def xml2obj(stream, klass = nil)
-      parser = SOAP::Parser.new(MAPPING_OPT)
+    def xml2obj(stream, klass = nil, options = {})
+      opt = MAPPING_OPT.dup.merge(options)
+      parser = SOAP::Parser.new(opt)
       soap = parser.parse(stream)
       SOAP::Mapping.soap2obj(soap, @registry, klass)
     end


### PR DESCRIPTION
Non-breaking change.

Adds `options = {}` argument to `XSD::Mapping::Mapper#obj2xml` and
`XSD::Mapping::Mapper#xml2obj` instance methods and `XSD::Mapping.obj2xml` and
`XSD::Mapping.xml2obj` module methods.

Currently, XML namespaces cannot be customized because the options for the
`SOAP::Generator` constructor are not exposed as an argument of the
`XSD::Mapping::Mapper#obj2xml` instance method and/or the `XSD::Mapping.obj2xml`
module method.

This commit enables the customization of XML namespaces. For example, to set the
default XML namespace:

```ruby
mapper.obj2xml(obj, nil, nil, { # indented for readability
  default_ns: SOAP::NS.new({
    "ex" => "http://example.com/ns#",
  }),
})
```