### PR TITLE
Fix Regexp.new ArgumentError on ruby 3.3

### DIFF
--- a/lib/soap/baseData.rb
+++ b/lib/soap/baseData.rb
@@ -1080,7 +1080,7 @@ private
     "#{typename}[" << ',' * (rank - 1) << ']'
   end
 
-  TypeParseRegexp = Regexp.new('^(.+)\[([\d,]*)\]$', nil, 'n')
+  TypeParseRegexp = Regexp.new('^(.+)\[([\d,]*)\]$', Regexp::NOENCODING)
 
   def self.parse_type(string)
     TypeParseRegexp =~ string

--- a/lib/soap/generator.rb
+++ b/lib/soap/generator.rb
@@ -270,7 +270,15 @@ private
   end
 
   def get_encode_char_regexp
-    ENCODE_CHAR_REGEXP[XSD::Charset.encoding] ||= Regexp.new("[#{EncodeMap.keys.join}]", nil, (RUBY_VERSION.to_f <= 1.8) ? XSD::Charset.encoding : nil) # RubyJedi: compatible with Ruby 1.8.6 and above
+    ENCODE_CHAR_REGEXP[XSD::Charset.encoding] ||= begin
+      if RUBY_VERSION.to_f <= 1.8
+        Regexp.new("[#{EncodeMap.keys.join}]", nil, XSD::Charset.encoding)
+      elsif RUBY_VERSION.to_f < 3.3
+        Regexp.new("[#{EncodeMap.keys.join}]", nil, nil) # RubyJedi: compatible with Ruby 1.8.6 and above
+      else
+        Regexp.new("[#{EncodeMap.keys.join}]")
+      end
+    end
   end
 
   def find_handler(encodingstyle)

--- a/lib/xsd/charset.rb
+++ b/lib/xsd/charset.rb
@@ -130,18 +130,18 @@ public
 
   # us_ascii = '[\x00-\x7F]'
   us_ascii = '[\x9\xa\xd\x20-\x7F]'	# XML 1.0 restricted.
-  USASCIIRegexp = Regexp.new("\\A#{us_ascii}*\\z", nil, 'n')
+  USASCIIRegexp = Regexp.new("\\A#{us_ascii}*\\z", Regexp::NOENCODING)
 
   twobytes_euc = '(?:[\x8E\xA1-\xFE][\xA1-\xFE])'
   threebytes_euc = '(?:\x8F[\xA1-\xFE][\xA1-\xFE])'
   character_euc = "(?:#{us_ascii}|#{twobytes_euc}|#{threebytes_euc})"
-  EUCRegexp = Regexp.new("\\A#{character_euc}*\\z", nil, 'n')
+  EUCRegexp = Regexp.new("\\A#{character_euc}*\\z", Regexp::NOENCODING)
 
   # onebyte_sjis = '[\x00-\x7F\xA1-\xDF]'
   onebyte_sjis = '[\x9\xa\xd\x20-\x7F\xA1-\xDF]'	# XML 1.0 restricted.
   twobytes_sjis = '(?:[\x81-\x9F\xE0-\xFC][\x40-\x7E\x80-\xFC])'
   character_sjis = "(?:#{onebyte_sjis}|#{twobytes_sjis})"
-  SJISRegexp = Regexp.new("\\A#{character_sjis}*\\z", nil, 'n')
+  SJISRegexp = Regexp.new("\\A#{character_sjis}*\\z", Regexp::NOENCODING)
 
   # 0xxxxxxx
   # 110yyyyy 10xxxxxx
@@ -152,7 +152,7 @@ public
   fourbytes_utf8 = '(?:[\xF0-\xF7][\x80-\xBF][\x80-\xBF][\x80-\xBF])'
   character_utf8 =
     "(?:#{us_ascii}|#{twobytes_utf8}|#{threebytes_utf8}|#{fourbytes_utf8})"
-  UTF8Regexp = Regexp.new("\\A#{character_utf8}*\\z", nil, 'n')
+  UTF8Regexp = Regexp.new("\\A#{character_utf8}*\\z", Regexp::NOENCODING)
 
   def Charset.is_us_ascii(str)
     USASCIIRegexp =~ str


### PR DESCRIPTION
Ruby 3.2 introduced a deprecation of the third positional parameter for encoding: https://github.com/ruby/ruby/commit/7e8fa06022a9e412e3f8e6c8b6f0ba1909f648d5

The argument was then removed in Ruby 3.3: https://github.com/ruby/ruby/commit/04cfb26bd394b8e92f24f18799f5e9fc96b2ea69

```
ArgumentError: wrong number of arguments (given 3, expected 1..2) (ArgumentError)

  USASCIIRegexp = Regexp.new("\\A#{us_ascii}*\\z", nil, 'n')
                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```