### PR TITLE
only call untaint on ruby < 2.7

### DIFF
--- a/lib/soap/mapping/literalregistry.rb
+++ b/lib/soap/mapping/literalregistry.rb
@@ -357,10 +357,12 @@ private
   # much memory for each singleton Object.  just instance_eval instead of it.
   def define_xmlattr_accessor(obj, qname)
     # untaint depends GenSupport.safemethodname
-    name = Mapping.safemethodname('xmlattr_' + qname.name).untaint
+    name = Mapping.safemethodname('xmlattr_' + qname.name)
+    name.untaint if RUBY_VERSION < '2.7'
     unless obj.respond_to?(name)
       # untaint depends QName#dump
-      qnamedump = qname.dump.untaint
+      qnamedump = qname.dump
+      qnamedump.untaint if RUBY_VERSION < '2.7'
       obj.instance_eval <<-EOS
         def #{name}
           @__xmlattr[#{qnamedump}]

--- a/lib/soap/mapping/mapping.rb
+++ b/lib/soap/mapping/mapping.rb
@@ -333,7 +333,8 @@ module Mapping
     else
       values.each do |attr_name, value|
         # untaint depends GenSupport.safevarname
-        name = Mapping.safevarname(attr_name).untaint
+        name = Mapping.safevarname(attr_name)
+        name.untaint if RUBY_VERSION < '2.7'
         setter = name + "="
         if obj.respond_to?(setter)
           obj.__send__(setter, value)

--- a/lib/soap/mapping/registry.rb
+++ b/lib/soap/mapping/registry.rb
@@ -107,9 +107,11 @@ private
   # much memory for each singleton Object.  just instance_eval instead of it.
   def __define_attr_accessor(qname)
     # untaint depends GenSupport.safemethodname
-    name = Mapping.safemethodname(qname.name).untaint
+    name = Mapping.safemethodname(qname.name)
+    name.untaint if RUBY_VERSION < '2.7'
     # untaint depends on QName#dump
-    qnamedump = qname.dump.untaint
+    qnamedump = qname.dump
+    qnamedump.untaint if RUBY_VERSION < '2.7'
     singleton = false
     unless self.respond_to?(name)
       singleton = true


### PR DESCRIPTION
I saw the issue was fixed in the fork @aogata-inst created, but there was no PR to the original project yet. Since it's a fork and the source is GPL, I don't think I'm doing anything wrong by creating a PR for this. Of course I take no credit, I did not fix the issue.

Original commit message from @aogata-inst:

According to https://bugs.ruby-lang.org/issues/16131, untaint is a no-op on all versions of ruby >= 2.7 and is completely removed on >= ruby 3.2.

Use the pattern established at https://github.com/ruby/reline/pull/61/files to only call this method when it’s relevant.